### PR TITLE
Fix a possible XP multiplication exploit

### DIFF
--- a/src/main/java/bl4ckscor3/mod/xptome/ItemXPTome.java
+++ b/src/main/java/bl4ckscor3/mod/xptome/ItemXPTome.java
@@ -35,7 +35,7 @@ public class ItemXPTome extends Item
 		ItemStack stack = player.getHeldItem(hand);
 		int storedXP = getStoredXP(stack);
 		
-		if(stack.stackSize > 1) // Only process one tome at a time
+		if(stack.getCount() > 1) // Only process one tome at a time
 			return new ActionResult<>(EnumActionResult.PASS, stack);
 
 		if(player.isSneaking() && storedXP < Configuration.maxXP)

--- a/src/main/java/bl4ckscor3/mod/xptome/ItemXPTome.java
+++ b/src/main/java/bl4ckscor3/mod/xptome/ItemXPTome.java
@@ -34,6 +34,9 @@ public class ItemXPTome extends Item
 	{
 		ItemStack stack = player.getHeldItem(hand);
 		int storedXP = getStoredXP(stack);
+		
+		if(stack.stackSize > 1) // Only process one tome at a time
+			return new ActionResult<>(EnumActionResult.PASS, stack);
 
 		if(player.isSneaking() && storedXP < Configuration.maxXP)
 		{


### PR DESCRIPTION
Some mods allow for stacking of usually unstackable items such as full XP books.

If using stacked XP books while not sneaking, the user will only empty one book but will gain the XP of the entire stack of XP books. Such behavior is exploitable in mod packs that combine the XP-Tome mod with mods that allow stacking of usually unstackable items.

This change fixes the possibility of an exploit, by cancelling the interaction with the book held if the user has any amount of books in their hand other than just the one.

---

## Context

Hey this mod is pretty sweet. Thank you for making it!

I'm here because while playing a 1.12 modpack that includes the Charm mod, I found it was possible to use its bookshelf chests, which only accept book-type items, to stack full (as well as empty) XP tomes. It was awesome. Then a friend discovered that you could actually right click on a stack to extract the full XP stored in all of its books, while only emptying one of them. This was exploitable to obtain infinite XP.

I tried to make a patch as non-invasive as possible, such that you could check it with the least amount of effort possible.

Thanks for reading so far, and I hope you consider accepting this PR <3